### PR TITLE
add have_library(‘rt’) to extconf for ubuntu

### DIFF
--- a/ext/posix/extconf.rb
+++ b/ext/posix/extconf.rb
@@ -1,3 +1,4 @@
 require 'mkmf'
 have_header('mqueue.h')
+have_library("rt")
 create_makefile('posix/mqueue')


### PR DESCRIPTION
gem compiles fine on ubuntu 14.04 but reports error when run:
posix-mqueue-0.0.7/posix/mqueue.so: undefined symbol: mq_open

This change solves this issue.
