### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ require 'posix/mqueue'
 # On Linux the queue name must be prefixed with a slash. Note it is not a file
 # created at `/whatever`. It's just the name of the queue.
 # Set maximum default Linux options. See next section to push those limits.
-# Default options are msgsize: 10 and maxmsg: 4096
-m = POSIX::Mqueue.new("/whatever", msgsize: 10, maxmsg: 8192)
+# Default options are msgsize: 4096 and maxmsg: 10
+m = POSIX::Mqueue.new("/whatever", msgsize: 8192, maxmsg: 10)
 m.send "hello"
 m.receive
 # => "hello"


### PR DESCRIPTION
Changed the order of values of the parameters maxmsg and msgsize in the example to be more clear.

@Sirupsen 
